### PR TITLE
Place the redirection to https on the vhost level

### DIFF
--- a/tasks/redirect_to_https.yml
+++ b/tasks/redirect_to_https.yml
@@ -1,5 +1,5 @@
-- template:
-    src: redirect_to_https.conf
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/redirect_to_https.conf"
+- file:
+    name: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/redirect_to_https.conf"
+    state: absent
   name: Set redirect_to_https.conf template for {{ _website_domain }}
   notify: verify config and restart httpd

--- a/templates/redirect_to_https.conf
+++ b/templates/redirect_to_https.conf
@@ -1,8 +1,0 @@
-# {{ ansible_managed }}
-{% if _force_tls %}
-RewriteEngine On
-# for lets encrypt automation
-RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/
-RewriteCond %{HTTPS} off
-RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} 
-{% endif %}

--- a/templates/vhost.conf
+++ b/templates/vhost.conf
@@ -2,8 +2,16 @@
 
 <VirtualHost *:{{ port }}>
         ServerName {{ _website_domain }}
-
+    {% if _force_tls %}
+        RewriteEngine On
+        # for lets encrypt automation
+        RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/
+        RewriteCond %{HTTPS} off
+        RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
+        Include /etc/httpd/conf.d/{{ _website_domain }}.conf.d/letsencrypt.conf
+    {% else %}
         Include /etc/httpd/conf.d/{{ _website_domain }}.conf.d/*conf
+    {% endif %}
 
 {% if port == '443' %}
         SSLEngine on


### PR DESCRIPTION
Since this directive take over the whole vhost, it doesn't make
sense to include others configuration.

This permit to also avoid corner case, such as what happen when
someone turn contradictory configuration (like proxy and
redirect to https and to another location).

A audit of others options to see which one need the same change will be done later.
