### PR TITLE
Do not declare WSGIDaemonProcess in a vhost

### DIFF
--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -5,3 +5,8 @@
     dest: /etc/httpd/conf.d/{{ _website_domain }}.conf.d/python.conf
   notify: verify config and restart httpd
 
+- name: Deploy WSGIDaemon for {{ _website_domain }}
+  template:
+    src: wsgi_daemon.conf
+    dest: /etc/httpd/conf.d/wsgi_daemon_{{ _website_domain }}.conf
+  notify: verify config and restart httpd

--- a/templates/python.conf
+++ b/templates/python.conf
@@ -1,6 +1,4 @@
 # {{ ansible_managed }}
 
-WSGIDaemonProcess {{ _website_domain }} home={{ document_root }} python-path={{ document_root }} display-name=wsgi_{{ _website_domain }} user={{ wsgi_user }} group={{ wsgi_user }} umask=0026 threads={{ wsgi_threads }}
-WSGIProcessGroup {{ _website_domain }}
 WSGIScriptAlias / "{{ wsgi_script }}"
 

--- a/templates/wsgi_daemon.conf
+++ b/templates/wsgi_daemon.conf
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+WSGIDaemonProcess {{ _website_domain }} home={{ document_root }} python-path={{ document_root }} display-name=wsgi_{{ _website_domain }} user={{ wsgi_user }} group={{ wsgi_user }} umask=0026 threads={{ wsgi_threads }}
+WSGIProcessGroup {{ _website_domain }}
+


### PR DESCRIPTION
Since it cannot be declared more than once, we need to have it declared
once per domain, and if possible outside of the conf.d/$DOMAIN.conf.d/
directory, since this would cause conflict with http and https
hosts as found out by Duck.
