### PR TITLE
Use torrc var for portability

### DIFF
--- a/tasks/hidden_service.yml
+++ b/tasks/hidden_service.yml
@@ -4,7 +4,7 @@
 
 - name: Add the HiddenServiceDir config to torrc
   blockinfile:
-    dest: /etc/tor/torrc
+    dest: "{{ torrc }}"
     block: |
       HiddenServiceDir {{ hs_dir }}
       HiddenServicePort 443 127.0.0.1:443


### PR DESCRIPTION
As of https://gitlab.com/osas/ansible-role-tor/merge_requests/3,
we use a variable for the torrc location for portability (mostly
on FreeBSD ports).
