### PR TITLE
Move letsencrypt_root to a var, due to declaration wrapped in when

### DIFF
--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -5,10 +5,6 @@
   with_items:
   - certbot
 
-- name: Set the variable for the root
-  set_fact:
-    letsencrypt_root: "/var/www/letsencrypt/{{ _website_domain }}/"
-
 #- user: system=yes name=_letsencrypt comment="Letsencrypt user, ansible created"
 
 - name: Create letsencrypt directory

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,1 @@
+letsencrypt_root: "/var/www/letsencrypt/{{ _website_domain }}/"


### PR DESCRIPTION
We used to have warning about this being deprecated in 2.1, and since
2.2 is soon(tm) out, better fix before the release.
