### PR TITLE
Fix some strange error regarding SSL

### DIFF
--- a/templates/vhost.conf
+++ b/templates/vhost.conf
@@ -13,7 +13,7 @@
         Include /etc/httpd/conf.d/{{ _website_domain }}.conf.d/*conf
     {% endif %}
 
-{% if port == '443' %}
+{% if port|int == 443 %}
         SSLEngine on
         CustomLog logs/ssl_request_log "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
         SSLCertificateKeyFile /etc/pki/tls/private/{{ _website_domain }}.key


### PR DESCRIPTION
For a reason I didn't understood yet, the port comparaison became
invalid, because port is a integer and not a string. This
wasn't detected sooner, because httpd didn't restart nor crashed in
production, so the right configuration was still there.

I suspect a ansible change somewhere, but I am not sure when,
I might dig later.
