### PR TITLE
ensure vhost config is before default packages config

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,6 @@ $ cat deploy_piwik.yml
 
 However, some variable name are a bit generic (like use_tls), so beware of this as it can produes weird side effects.
 
-In order to let a role extend the httpd configuration, a role can drop files ending in .conf in /etc/httpd/conf.d/$DOMAIN.conf.d/.
+In order to let a role extend the httpd configuration, a role can drop files ending in .conf in /etc/httpd/conf.d/50\_$DOMAIN.conf.d/.
 The file will be included for TLS and non TLS vhost for now, which might cause some issues. This is planned to be fixed later
 to be able to support WSGI cleanly.

--- a/tasks/aliases.yml
+++ b/tasks/aliases.yml
@@ -1,5 +1,5 @@
 - template:
     src: aliases.conf
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/aliases.conf"
+    dest: "{{ _vhost_confdir }}/aliases.conf"
   notify: verify config and restart httpd
   name: Set aliases.conf template for {{ _website_domain }}

--- a/tasks/document_root.yml
+++ b/tasks/document_root.yml
@@ -1,5 +1,5 @@
 - name: Install document root configuration
   template:
     src: document_root.conf
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/document_root.conf"
+    dest: "{{ _vhost_confdir }}/document_root.conf"
   notify: verify config and restart httpd

--- a/tasks/hidden_service.yml
+++ b/tasks/hidden_service.yml
@@ -21,6 +21,6 @@
 
 - name: Deploy the httpd config for onion
   copy:
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/hidden_service.conf"
+    dest: "{{ _vhost_confdir }}/hidden_service.conf"
     content: "ServerAlias {{ onion_hostname }}"
   notify: verify config and restart httpd

--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -22,7 +22,7 @@
 - name: Deploy letsencrypt.conf httpd config
   template:
     src: letsencrypt.conf
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/letsencrypt.conf"
+    dest: "{{ _vhost_confdir }}/letsencrypt.conf"
   when: website_domain is defined
   notify: verify config and restart httpd
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,10 @@
 - set_fact:
     _force_tls: False
     _use_tls: False
+    _vhost_old_conffile_prefix: "/etc/httpd/conf.d/{{ _website_domain }}"
+    _vhost_old_confdir: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d"
+    _vhost_conffile_prefix: "/etc/httpd/conf.d/50_{{ _website_domain }}"
+    _vhost_confdir: "/etc/httpd/conf.d/50_{{ _website_domain }}.conf.d"
 
 - set_fact:
     _force_tls: "{{ force_tls }}"
@@ -52,13 +56,13 @@
   name: Set document root configuration
 
 - file:
-    path: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/"
+    path: "{{ _vhost_confdir }}"
     state: directory
   name: Create configuration directory for {{ _website_domain }}
 
 # needed for newer apache, who requires at least 1 file for include
 - copy:
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/placeholder.conf"
+    dest: "{{ _vhost_confdir }}/placeholder.conf"
     content: "# Placeholder"
   name: Create placeholder configuration for {{ _website_domain }}
 
@@ -76,7 +80,7 @@
 
 - template:
     src: vhost.conf
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf"
+    dest: "{{ _vhost_conffile_prefix }}.conf"
     owner: root
     group: apache
     mode: 0644
@@ -112,12 +116,21 @@
 
 - template:
     src: vhost.conf
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}_ssl.conf"
+    dest: "{{ _vhost_conffile_prefix }}_ssl.conf"
     owner: root
     group: apache
     mode: 0644
   notify: verify config and restart httpd
   when: _use_tls
+
+- name: remove obsolete config files
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+  - "{{ _vhost_old_conffile_prefix }}.conf"
+  - "{{ _vhost_old_conffile_prefix }}_ssl.conf"
+  - "{{ _vhost_old_confdir }}"
 
 # cleanup of variables, since they leak to subsequent role run
 #

--- a/tasks/mod_speling.yml
+++ b/tasks/mod_speling.yml
@@ -1,6 +1,6 @@
 - name: Deploy mod_speling
   template:
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/mod_speling.conf"
+    dest: "{{ _vhost_confdir }}/mod_speling.conf"
     src: mod_speling.conf
     mode: 0644
   notify: verify config and restart httpd

--- a/tasks/password_absent.yml
+++ b/tasks/password_absent.yml
@@ -5,6 +5,6 @@
 
 - name: Remove the website password protection
   file:
-    path: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/password.conf"
+    path: "{{ _vhost_confdir }}/password.conf"
     state: absent
   notify: verify config and restart httpd

--- a/tasks/password_present.yml
+++ b/tasks/password_present.yml
@@ -10,6 +10,6 @@
 - name: Deploy the website password protection
   template:
     src: password.conf
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/password.conf"
+    dest: "{{ _vhost_confdir }}/password.conf"
   notify: verify config and restart httpd
   no_log: True

--- a/tasks/python.yml
+++ b/tasks/python.yml
@@ -2,6 +2,6 @@
 - name: Set python.conf template for {{ _website_domain }}
   template:
     src: python.conf
-    dest: /etc/httpd/conf.d/{{ _website_domain }}.conf.d/python.conf
+    dest: "{{ _vhost_confdir }}/python.conf"
   notify: verify config and restart httpd
 

--- a/tasks/redirect.yml
+++ b/tasks/redirect.yml
@@ -1,5 +1,5 @@
 - template:
     src: redirect.conf
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/redirect.conf"
+    dest: "{{ _vhost_confdir }}/redirect.conf"
   notify: verify config and restart httpd
   name: Set redirect.conf template for {{ _website_domain }}

--- a/tasks/redirect_to_https.yml
+++ b/tasks/redirect_to_https.yml
@@ -1,5 +1,5 @@
 - file:
-    name: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/redirect_to_https.conf"
+    name: "{{ _vhost_confdir }}/redirect_to_https.conf"
     state: absent
   name: Set redirect_to_https.conf template for {{ _website_domain }}
   notify: verify config and restart httpd

--- a/tasks/redirects.yml
+++ b/tasks/redirects.yml
@@ -1,5 +1,5 @@
 - template:
     src: redirects.conf
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/redirects.conf"
+    dest: "{{ _vhost_confdir }}/redirects.conf"
   notify: verify config and restart httpd
   name: Set redirects.conf template for {{ _website_domain }}

--- a/tasks/reverse_proxy.yml
+++ b/tasks/reverse_proxy.yml
@@ -1,4 +1,4 @@
 - template:
     src: reverse_proxy.conf
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/reverse_proxy.conf"
+    dest: "{{ _vhost_confdir }}/reverse_proxy.conf"
   notify: verify config and restart httpd

--- a/tasks/server_alias.yml
+++ b/tasks/server_alias.yml
@@ -1,5 +1,5 @@
 - name: Install server alias configuration
   template:
     src: server_alias.conf
-    dest: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d/server_alias.conf"
+    dest: "{{ _vhost_confdir }}/server_alias.conf"
   notify: verify config and restart httpd

--- a/templates/vhost.conf
+++ b/templates/vhost.conf
@@ -8,9 +8,9 @@
         RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/
         RewriteCond %{HTTPS} off
         RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
-        Include /etc/httpd/conf.d/{{ _website_domain }}.conf.d/letsencrypt.conf
+        Include {{ _vhost_confdir }}/letsencrypt.conf
     {% else %}
-        Include /etc/httpd/conf.d/{{ _website_domain }}.conf.d/*conf
+        Include {{ _vhost_confdir }}/*conf
     {% endif %}
 
 {% if port|int == 443 %}


### PR DESCRIPTION
I had a config name t*.conf, which was then after ssl.conf provided by the mod_ssl package. Unfortunately the load order make the defaut vhost in ssl.conf override the one I configured using this role and the browser warned me the site was using a self-signed certificate (as provided/generated by the package).

So this patch simply ensure vhost config is before any package config but still leaves room for ordering things before and in-between. Previous useless files are removed. It btw uses variables to ease reading and possible future transitions.
