### PR TITLE
[DEFER] Add support OCSP Stapling on Apache 2.4

### DIFF
--- a/templates/vhost.conf
+++ b/templates/vhost.conf
@@ -21,6 +21,12 @@
         SSLCertificateFile /etc/pki/tls/certs/{{ _website_domain }}.crt
         Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
 
+        <IfVersion >= 2.4>
+        SSLUseStapling on
+        SSLStaplingReturnResponderErrors off
+        SSLStaplingResponderTimeout 5
+        SSLStaplingCache shmcb:/run/httpd/ssl_stapling(32768)
+        </IfVersion>
         # taken on https://wiki.mozilla.org/Security/Server_Side_TLS
         SSLCipherSuite  ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK
 {% endif %}


### PR DESCRIPTION
While this is likely just extra security, this should improve
performance in case clients do OCSP verification.