### PR TITLE
Set a explicit location for logs

### DIFF
--- a/templates/vhost.conf
+++ b/templates/vhost.conf
@@ -14,8 +14,10 @@
     {% endif %}
 
 {% if port|int == 443 %}
+        ErrorLog logs/{{ _website_domain }}_ssl_error.log
+        CustomLog logs/{{ _website_domain }}_ssl_access.log "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+
         SSLEngine on
-        CustomLog logs/ssl_request_log "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
         SSLCertificateKeyFile /etc/pki/tls/private/{{ _website_domain }}.key
         SSLCertificateChainFile /etc/pki/tls/certs/{{ _website_domain }}.ca.crt
         SSLCertificateFile /etc/pki/tls/certs/{{ _website_domain }}.crt
@@ -23,6 +25,9 @@
 
         # taken on https://wiki.mozilla.org/Security/Server_Side_TLS
         SSLCipherSuite  ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK
+{% else %}
+        ErrorLog logs/{{ _website_domain }}_error.log
+        CustomLog logs/{{ _website_domain }}_access.log combined
 {% endif %}
 
 </VirtualHost>


### PR DESCRIPTION
After having to debug some proxy issue, I found out that there
was no log for ssl error, and that all vhost logs went to the
same file. So this will just make sure we have all logs
properly separated.