### PR TITLE
Set ServerName to a invalid value

### DIFF
--- a/files/various.conf
+++ b/files/various.conf
@@ -5,3 +5,10 @@ ServerTokens Prod
 ServerSignature Off
 # used for log analysis
 HostnameLookups On
+# fix https://github.com/OSAS/ansible-role-httpd/issues/12
+# We need to set Servername 
+# since the _default_ vhost will shadow the vhost set on the 
+# the hostname, as ServerName
+# is set by default to the value returned by hostname 
+# this, and some order of loading issue
+ServerName invalid.invalid


### PR DESCRIPTION
It was found while investigating #12 that _default_ vhost
sometime take over the vhost configuration we did define. The
condition are rather tricky to see something:
- we need a SSL enabled host
- it need to be on Apache 2.4
- the hostname must be the same as the vhost
- the hostname must be after ssl.conf using the current
file loading order (currently based on filename and alphabetical
order).

So the trick is either to change the load order (which is IMHO
too much hassle), or override the default Servername to avoid
problem.

Should fix #12