### PR TITLE
Add various standard security policy as recommended by Mozilla

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,17 @@ But usually, for cleaner URL, a redirect is preferred.
 Administrators wishing to use mod_speling can juse use `use_mod_speling: True` in the definition
 of the vhost.
 
+## Security settings
+
+By default, several HTTP headers are set to protect the website. There is currently no way to disable them, but
+this will be added if needed. The current settings are:
+
+- Content-Security-Policy, set to "frame-ancestors 'none'"
+- X-Frame-Options, set to DENY
+- X-Content-Type-Options: nosniff
+
+See https://wiki.mozilla.org/Security/Guidelines/Web_Security for more information.
+
 # Extend the role
 
 In order to compose more complex roles by combining (and using depends), the installed configuration also

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,6 +73,8 @@
 
 - include: mod_speling.yml
 
+- include: various_security.yml
+
 - set_fact:
     port: 80
 

--- a/tasks/various_security.yml
+++ b/tasks/various_security.yml
@@ -1,0 +1,5 @@
+- name: Install server alias configuration
+  template:
+    src: various_security.conf
+    dest: "{{ _vhost_confdir }}/various_security.conf"
+  notify: verify config and restart httpd

--- a/templates/various_security.conf
+++ b/templates/various_security.conf
@@ -1,0 +1,5 @@
+# https://wiki.mozilla.org/Security/Guidelines/Web_Security#X-Frame-Options
+Header always set Content-Security-Policy "frame-ancestors 'none'"
+Header always set X-Frame-Options "DENY"
+# https://wiki.mozilla.org/Security/Guidelines/Web_Security#X-Content-Type-Options
+X-Content-Type-Options: nosniff


### PR DESCRIPTION
While trying to see how much we would score on https://observatory.mozilla.org/,
I stumbled on various headers that would help and prevent whole class of attack,
such as clickjacking.

However, the most interesting settings would be to disable XSS with inline-javascript,
and this would likely requires auditing all websites first.