### PR TITLE
Use default rather than set_fact for _website_domain

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,14 +3,6 @@
   fail: msg="Redirect should be a complete URL, not {{ redirect }}"
   when: "redirect is defined and not redirect | match('^https?://.*/')"
 
-- set_fact:
-    _website_domain: "{{ website_domain }}"
-  when: website_domain is defined
-
-- set_fact:
-    _website_domain: "{{ ansible_fqdn }}"
-  when: website_domain is not defined
-
 - include: compat.yml
 
 - set_fact:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,1 +1,2 @@
 letsencrypt_root: "/var/www/letsencrypt/{{ _website_domain }}/"
+_website_domain: "{{ website_domain | default(ansible_fqdn) }}"


### PR DESCRIPTION
Main reason is that the munin role is using some trick to
be deployed on the whole server for the client, and just
on the server for the server part. However, this trick break now
since _website_domain is undefined (since that's done dynamically
with set_fact, who is skipped).

So I have to make sure there is a deault value in vars to make it
run.