### PR TITLE
Fix regexp and backref for mod_security

### DIFF
--- a/tasks/mod_security.yml
+++ b/tasks/mod_security.yml
@@ -10,7 +10,8 @@
 
 - lineinfile:
     dest: /etc/httpd/conf.d/mod_security.conf
-    regexp: "^(\\s*)SecRuleEngine "
+    regexp: '^(\s*)SecRuleEngine '
     line: "\\1SecRuleEngine {{ 'DetectionOnly' if mod_sec_detection_only else 'On' }}"
+    backrefs: yes
   notify: verify config and restart httpd
   name: Deploy modsecurity in apache


### PR DESCRIPTION
I suspect it was working by error in the past, since it now fail.