### PR TITLE
allow unmanaged document_root creation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,4 @@ server_aliases: []
 redirects: []
 allow_app_signals: False
 wsgi_threads: 5
+skip_document_root_creation: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
     owner: root
     mode: 0755
     group: root
-  when: document_root is defined
+  when: document_root is defined and not skip_document_root_creation
   name: Set document root configuration
 
 - file:


### PR DESCRIPTION
I needed to publish static content from a non-root builder and creation and permissions of the document_root are enforced by the role, which is really cumbersome.

So this is not a wonderful solution, but I need it badly.

Also I wonder if doing such a job is really appropriate. I would rather document to ensure permissions (including selinux) but leave it to the role user to do so.
