### PR TITLE
Make mod_security be activated on a per vhost basis

### DIFF
--- a/tasks/mod_security.yml
+++ b/tasks/mod_security.yml
@@ -8,10 +8,16 @@
   notify: verify config and restart httpd
   name: Install mod_security packages
 
-- lineinfile:
+- name: Disable mod_security for all vhost
+  lineinfile:
     dest: /etc/httpd/conf.d/mod_security.conf
     regexp: '^(\s*)SecRuleEngine '
-    line: "\\1SecRuleEngine {{ 'DetectionOnly' if mod_sec_detection_only else 'On' }}"
+    line: "\\1SecRuleEngine Off"
     backrefs: yes
   notify: verify config and restart httpd
-  name: Deploy modsecurity in apache
+
+- name: Enable mod_security on a vhost
+  template:
+    src: mod_security.conf
+    dest: "{{ _vhost_confdir }}/mod_security.conf"
+  notify: verify config and restart httpd

--- a/templates/mod_security.conf
+++ b/templates/mod_security.conf
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+SecRuleEngine {{ 'DetectionOnly' if mod_sec_detection_only else 'On' }}


### PR DESCRIPTION
The previous code was activating mod_security for the
whole server, which is a issue when trying to host
multiple web application (such as the gluster reverse proxy).

This was also rather unepxected to see that 1 instance of the role
would impact other unrelated role.