### PR TITLE
Make letsencrypt work also with reverse proxy

### DIFF
--- a/templates/reverse_proxy.conf
+++ b/templates/reverse_proxy.conf
@@ -3,6 +3,6 @@
 SSLProxyEngine on
 {% endif %}
 ProxyPreserveHost On
-ProxyPass / {{ reverse_proxy }}
+ProxyPassMatch !^/.well-known/acme-challenge/ {{ reverse_proxy }}
 ProxyPassReverse / {{ reverse_proxy }}
 {% endif %}


### PR DESCRIPTION
That's basically the same kind of issues fixed by 4e22d8b42.
The proxy should move everything but the letsencrypt negociation.

This part is also needing a bit of refactoring anyway, but this
is the least intrusive fix I could find for now.