### PR TITLE
Make letsencrypt work also with reverse proxy

### DIFF
--- a/tasks/reverse_proxy.yml
+++ b/tasks/reverse_proxy.yml
@@ -1,4 +1,5 @@
-- template:
-    src: reverse_proxy.conf
-    dest: "{{ _vhost_confdir }}/reverse_proxy.conf"
+# TODO remove after August 2017
+- file:
+    name: "{{ _vhost_confdir }}/reverse_proxy.conf"
+    state: absent
   notify: verify config and restart httpd

--- a/templates/reverse_proxy.conf
+++ b/templates/reverse_proxy.conf
@@ -1,8 +1,0 @@
-{% if reverse_proxy is defined %}
-{% if reverse_proxy | match('^https://.*') %}
-SSLProxyEngine on
-{% endif %}
-ProxyPreserveHost On
-ProxyPass / {{ reverse_proxy }}
-ProxyPassReverse / {{ reverse_proxy }}
-{% endif %}

--- a/templates/vhost.conf
+++ b/templates/vhost.conf
@@ -2,12 +2,18 @@
 
 <VirtualHost *:{{ port }}>
         ServerName {{ _website_domain }}
-    {% if _force_tls and port|int == 80 %}
+    {% if (_force_tls and port|int == 80) or reverse_proxy is defined %}
         RewriteEngine On
         # for lets encrypt automation
         RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/
-        RewriteCond %{HTTPS} off
-        RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
+
+        {% if _force_tls %}
+          RewriteCond %{HTTPS} off
+          RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI}
+        {% else if reverse_proxy is defined %}
+          RewriteRule .* {{ reverse_proxy }}%{REQUEST_URI} [L,P]
+        {% endif %}
+
         Include {{ _vhost_confdir }}/letsencrypt.conf
     {% else %}
         Include {{ _vhost_confdir }}/*conf


### PR DESCRIPTION
That's basically the same kind of issues fixed by 4e22d8b42.
The proxy should move everything but the letsencrypt negociation.

Using ProxyPassmatch didn't seems to work on 2.2, so I have to use
mod_rewrite

And refactoring it directly in vhost.conf permit to have less code
around (ie, no duplication of letsencrypt exception), and permit
to deal with conflicting settings (ie, if someone use reverse_proxy
and force_tls, for example ).