### PR TITLE
Fix condition for rewrite rules

### DIFF
--- a/templates/vhost.conf
+++ b/templates/vhost.conf
@@ -7,7 +7,7 @@
         # for lets encrypt automation
         RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/
 
-        {% if _force_tls %}
+        {% if (_force_tls and port|int == 80) %}
           RewriteCond %{HTTPS} off
           RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI}
         {% elif reverse_proxy is defined %}


### PR DESCRIPTION
So on gluster, we found that forcing tls and using reverse proxy is a corner case
that current code didn't handle, because the conditional was not copied
twice. So in turn, this did disable the rewrite in the case of https, which
is not the intended effects.