### PR TITLE
rework to split role responsabilities

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ use_mod_sec: False
 use_hidden_service: False
 use_tls: False
 use_mod_speling: False
+use_wsgi: False
 aliases: []
 server_aliases: []
 redirects: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,8 +4,8 @@ galaxy_info:
   description: Simple ansible role to manage httpd, used by others modules
   company: Red Hat
   license: MIT
-  # Use 2.0 due to the tor package requirements
-  min_ansible_version: 2.0
+  # Use 2.2 due to the include_role module
+  min_ansible_version: 2.2
   # Only tested with EL 7 and EL 6. No reason anything do 
   # not work anywhere else, just no time to test.
   # I would welcome patches 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,122 +1,24 @@
 ---
-- name: "Verify redirect value and fail"
-  fail: msg="Redirect should be a complete URL, not {{ redirect }}"
-  when: "redirect is defined and not redirect | match('^https?://.*/')"
 
-- include: compat.yml
+- name: Include common setup of httpd
+  include: common.yml
+  when: httpd_common is not defined
 
-- set_fact:
-    _force_tls: False
-    _use_tls: False
-    _vhost_conffile_prefix: "/etc/httpd/conf.d/{{ _website_domain }}"
-    _vhost_confdir: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d"
+- name: Include common vhost variables
+  include: vhost_vars.yml
 
-- set_fact:
-    _force_tls: "{{ force_tls }}"
-  when: force_tls
-  name: Set force_tls if force_tls is defined
+- name: test if canonical vhost is installed
+  stat:
+    path: "{{ _vhost_conffile_prefix }}.conf"
+  register: canonical_vhost
 
-- include: common.yml
-  when: _httpd_common is not defined
-  name: Include common setup of httpd
+- name: Setup canonical vhost if not yet defined
+  include: vhost.yml
+  vars:
+    _website_domain: "{{ ansible_fqdn }}"
+    use_tls: False
+    use_letsencrypt: False
+    use_freeipa: False
+  static: no
+  when: "not canonical_vhost.stat.exists"
 
-- set_fact:
-    _use_tls: True
-  when: use_letsencrypt or use_freeipa or use_tls
-  name: Set use_tls
-
-- fail:
-    msg: "Cannot set force_tls without any TLS method"
-  when: _force_tls and not _use_tls
-
-- include: common_tls.yml
-  when: _use_tls and _httpd_common_tls is not defined
-
-- include: common_wsgi.yml
-  when: wsgi_script is defined and wsgi_script and _httpd_common_wsgi is not defined
-
-- file:
-    state: directory
-    path: "{{ document_root }}"
-    setype: httpd_sys_content_t
-    owner: root
-    group: "{{ document_root_group | default('root') }}"
-    mode: 0775
-  when: document_root is defined
-  name: Set document root configuration
-
-- file:
-    path: "{{ _vhost_confdir }}"
-    state: directory
-  name: Create configuration directory for {{ _website_domain }}
-
-# needed for newer apache, who requires at least 1 file for include
-- copy:
-    dest: "{{ _vhost_confdir }}/placeholder.conf"
-    content: "# Placeholder"
-  name: Create placeholder configuration for {{ _website_domain }}
-
-- include: password.yml
-  when: website_user is defined
-
-- include: document_root.yml
-
-- include: server_alias.yml
-
-- include: mod_speling.yml
-
-- set_fact:
-    port: 80
-
-- template:
-    src: vhost.conf
-    dest: "{{ _vhost_conffile_prefix }}.conf"
-    owner: root
-    group: apache
-    mode: 0644
-  notify: verify config and restart httpd
-
-- include: redirect.yml
-
-- include: redirects.yml
-
-- include: aliases.yml
-
-- include: letsencrypt.yml
-  when: use_letsencrypt
-
-- include: freeipa.yml
-  when: use_freeipa
-
-- include: reverse_proxy.yml
-
-- include: mod_security.yml
-  when: use_mod_sec
-
-- include: redirect_to_https.yml
-
-- include: wsgi.yml
-  when: wsgi_script is defined and wsgi_script
-
-- include: hidden_service.yml
-  when: use_hidden_service
-
-- set_fact:
-    port: 443
-
-- template:
-    src: vhost.conf
-    dest: "{{ _vhost_conffile_prefix }}_ssl.conf"
-    owner: root
-    group: apache
-    mode: 0644
-  notify: verify config and restart httpd
-  when: _use_tls
-
-# cleanup of variables, since they leak to subsequent role run
-#
-# due to https://github.com/ansible/ansible/issues/14472
-- set_fact:
-    _force_tls: False
-    _use_tls: False
-  name: Clean force_tls and use_tls

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -1,0 +1,7 @@
+---
+
+# regenerate templates affecting server-level configuration
+
+- include: common_wsgi.yml
+  when: use_wsgi
+

--- a/tasks/vhost.yml
+++ b/tasks/vhost.yml
@@ -1,0 +1,101 @@
+---
+
+- name: "Verify redirect value and fail"
+  fail: msg="Redirect should be a complete URL, not {{ redirect }}"
+  when: "redirect is defined and not redirect | match('^https?://.*/')"
+
+- name: Include common vhost variables
+  include: vhost_vars.yml
+
+- name: Include common setup of httpd
+  include: common.yml
+  when: httpd_common is not defined
+
+- include: common_tls.yml
+  when: _use_tls and httpd_common_tls is not defined
+
+- file:
+    state: directory
+    path: "{{ document_root }}"
+    setype: httpd_sys_content_t
+    owner: root
+    group: "{{ document_root_group | default('root') }}"
+    mode: 0775
+  when: document_root is defined
+  name: Set document root configuration
+
+- file:
+    path: "{{ _vhost_confdir }}"
+    state: directory
+  name: Create configuration directory for {{ _website_domain }}
+
+# needed for newer apache, who requires at least 1 file for include
+- copy:
+    dest: "{{ _vhost_confdir }}/placeholder.conf"
+    content: "# Placeholder"
+  name: Create placeholder configuration for {{ _website_domain }}
+
+- include: password.yml
+  when: website_user is defined
+
+- include: document_root.yml
+
+- include: server_alias.yml
+
+- include: mod_speling.yml
+
+- set_fact:
+    port: 80
+
+- template:
+    src: vhost.conf
+    dest: "{{ _vhost_conffile_prefix }}.conf"
+    owner: root
+    group: apache
+    mode: 0644
+  notify: verify config and restart httpd
+
+- include: redirect.yml
+
+- include: redirects.yml
+
+- include: aliases.yml
+
+- include: letsencrypt.yml
+  when: use_letsencrypt
+
+- include: freeipa.yml
+  when: use_freeipa
+
+- include: reverse_proxy.yml
+
+- include: mod_security.yml
+  when: use_mod_sec
+
+- include: redirect_to_https.yml
+
+- include: wsgi.yml
+  when: wsgi_script is defined and wsgi_script
+
+- include: hidden_service.yml
+  when: use_hidden_service
+
+- set_fact:
+    port: 443
+
+- template:
+    src: vhost.conf
+    dest: "{{ _vhost_conffile_prefix }}_ssl.conf"
+    owner: root
+    group: apache
+    mode: 0644
+  notify: verify config and restart httpd
+  when: _use_tls
+
+# cleanup of variables, since they leak to subsequent role run
+#
+# due to https://github.com/ansible/ansible/issues/14472
+- set_fact:
+    _force_tls: False
+    _use_tls: False
+  name: Clean force_tls and use_tls

--- a/tasks/vhost_vars.yml
+++ b/tasks/vhost_vars.yml
@@ -1,0 +1,20 @@
+---
+
+- include: compat.yml
+
+- set_fact:
+    _use_tls: False
+    _force_tls: False
+    _vhost_conffile_prefix: "/etc/httpd/conf.d/{{ _website_domain }}"
+    _vhost_confdir: "/etc/httpd/conf.d/{{ _website_domain }}.conf.d"
+
+- name: Set use_tls
+  set_fact:
+    _use_tls: True
+  when: use_letsencrypt or use_freeipa or use_tls
+
+- name: Set force_tls if force_tls is defined
+  set_fact:
+    _force_tls: "{{ force_tls }}"
+  when: force_tls
+

--- a/tasks/wsgi.yml
+++ b/tasks/wsgi.yml
@@ -1,13 +1,23 @@
 ---
-- name: Set wsgi.conf template for {{ _website_domain }}
+
+- name: Include common vhost variables
+  include: vhost_vars.yml
+
+- include: common_wsgi.yml
+  when: _httpd_common_wsgi is not defined
+
+- name: Set wsgi.conf template for WSGI instance {{ wsgi_instance }}
   template:
     src: wsgi.conf
-    dest: "{{ _vhost_confdir }}/wsgi.conf"
+    dest: "{{ _vhost_confdir }}/wsgi_{{ wsgi_instance }}.conf"
   notify: verify config and restart httpd
 
 # TODO remove after May 2018
 - file:
-    name: "{{ _vhost_confdir }}/python.conf"
+    name: "{{ item }}"
     state: absent
+  with_items:
+    - "{{ _vhost_confdir }}/python.conf"
+    - "{{ _vhost_confdir }}/wsgi.conf"
   notify: verify config and restart httpd
 

--- a/templates/wsgi.conf
+++ b/templates/wsgi.conf
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-WSGIDaemonProcess {{ _website_domain }} home={{ document_root }} python-path={{ document_root }} display-name=wsgi_{{ _website_domain }} user={{ wsgi_user }} group={{ wsgi_user }} umask=0026 threads={{ wsgi_threads }}
-WSGIProcessGroup {{ _website_domain }}
+WSGIDaemonProcess {{ wsgi_instance }} home={{ wsgi_home }} python-path={{ wsgi_home }} display-name=wsgi_{{ wsgi_instance }} user={{ wsgi_user }} group={{ wsgi_user }} umask=0026 threads={{ wsgi_threads }}
+WSGIProcessGroup {{ wsgi_instance }}
 WSGIScriptAlias / "{{ wsgi_script }}"
 


### PR DESCRIPTION
So the goal is to define a draf to split the role responsabilities (server config, vhost config, specific instance config).

The WSGI part has been changed to have a consistent work and a working example of the third case.

This is just a draft to see if we can agree on changes, and I'll work on polishing and documenting along the way.

The mailing-lists-server role has been adapted to show a working example: https://gitlab.com/osas/ansible-role-mailing-lists-server/merge_requests/1