### PR TITLE
reload httpd after letsencrypt cert generation

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,9 @@
 
 - name: restart httpd
   service: name=httpd state=restarted
+
+- name: reload httpd
+  service:
+    name: httpd
+    state: reloaded
+

--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -34,6 +34,7 @@
   command: certbot --text --renew-by-default --rsa-key-size 3072 --email root+lets-{{ _website_domain }}@{{ mail_domain | default(ansible_domain) }} --domains {{ _website_domain }} --agree-tos --webroot --webroot-path {{ letsencrypt_root }} certonly
   args:
     creates: "/etc/letsencrypt/live/{{ _website_domain }}/privkey.pem"
+  notify: reload httpd
 
 - name: Deploy the cron to renew
   copy:


### PR DESCRIPTION
In case the server is already deployed with letsencrypt support and you
force the regeneration of the certificate, the server was not reloaded
and the new certificate was not taken into account.