### PR TITLE
Fix the letsencrypt CA.

### DIFF
--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -49,4 +49,4 @@
   with_items:
   - { src: 'privkey.pem',   dst: 'private/{{ _website_domain }}.key' }
   - { src: 'cert.pem',      dst: 'certs/{{ _website_domain }}.crt' }
-  - { src: 'fullchain.pem', dst: 'certs/{{ _website_domain }}.ca.crt' }
+  - { src: 'chain.pem', dst: 'certs/{{ _website_domain }}.ca.crt' }


### PR DESCRIPTION
See https://github.com/gluster/glusterfs-debian/issues/4

In short, we serve the certificate and the CA, and apt do not like
it. So using only the chain.pem instead of fullchain.pem
should be sufficient.